### PR TITLE
fix interpSetGlyph()

### DIFF
--- a/Delorean/Delorean.roboFontExt/lib/delorean.py
+++ b/Delorean/Delorean.roboFontExt/lib/delorean.py
@@ -190,6 +190,9 @@ class Dialog(BaseWindowController):
     #     fontName = family+' '+style
 
     def interpSetGlyph(self, gname):
+        
+        font1 = self.font1
+        font2 = self.font2
 
         if gname in font1 and gname in font2:
 


### PR DESCRIPTION
interpSetGlyph() wasn't getting the font1 and font2 variables from the parent class